### PR TITLE
Add progress logging and replace print() with log_all()/log_once()

### DIFF
--- a/conv/epip_db_to_xml.py
+++ b/conv/epip_db_to_xml.py
@@ -11,8 +11,11 @@ import logging
 def epip_db_to_xml(database_epip: Path, output_filename: Path) -> None:
     with MdbxStorage(database_epip) as db_epip:
         with db_epip.env.ro_transaction() as txn:
+            log_all(logging.INFO, f"[epip_db_to_xml] building EPIP publication delivery from {database_epip}")
             publication_delivery: PublicationDelivery = export_epip_network_offer(db_epip, txn)
+            log_all(logging.INFO, f"[epip_db_to_xml] serialising to {output_filename}")
             export_publication_delivery_xml(publication_delivery, output_filename)
+            log_all(logging.INFO, f"[epip_db_to_xml] done: {output_filename}")
 
 
 def main(source: str, target: str) -> None:

--- a/conv/gtfs_db_to_gtfs.py
+++ b/conv/gtfs_db_to_gtfs.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from itertools import groupby
 from pathlib import Path
 from typing import List, Iterator, cast, Any
@@ -35,6 +36,7 @@ from domain.netex.model import (
 
 import zipfile
 from configuration import defaults
+from utils.aux_logging import prepare_logger
 
 
 def extract(archive: zipfile.ZipFile, database: Path) -> None:
@@ -325,6 +327,7 @@ if __name__ == '__main__':
     argument_parser = argparse.ArgumentParser(description='Convert prepared lmdb database into GTFS')
     argument_parser.add_argument('netex', type=str, help='The lmdb database')
     argument_parser.add_argument('gtfs', type=str, help='The output gtfs filename')
-    argument_parser.add_argument('--log_file', type=str, required=False, help='the logfile')  # TODO: use logger in this file
+    argument_parser.add_argument('--log_file', type=str, required=False, help='the logfile')
     args = argument_parser.parse_args()
+    prepare_logger(logging.INFO, args.log_file)
     main(args.netex, args.gtfs)

--- a/conv/netex_db_to_generalframe.py
+++ b/conv/netex_db_to_generalframe.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from storage.mdbx.core.implementation import MdbxStorage
 from transformers.generalframe import export_to_general_frame
 from storage.lxml.serialization.xml import export_publication_delivery_xml
-from utils.aux_logging import log_all
+from utils.aux_logging import log_all, prepare_logger
 
 
 def netex_db_to_generalframe(source: Path, target: Path) -> None:
+    log_all(logging.INFO, f"[netex_db_to_generalframe] exporting {source} to {target}")
     with MdbxStorage(source) as storage:
         with storage.env.ro_transaction() as txn:
             publication_delivery = export_to_general_frame(storage, txn)
@@ -30,6 +31,8 @@ if __name__ == '__main__':
     argument_parser = argparse.ArgumentParser(description='Export any lmdb file into a NeTEx GeneralFrame')
     argument_parser.add_argument('database', type=str, help='lmdb to be read from')
     argument_parser.add_argument('output_filename', type=str, help='The output XML file')
+    argument_parser.add_argument('--log_file', type=str, required=False, help='the logfile')
     args = argument_parser.parse_args()
+    prepare_logger(logging.INFO, args.log_file)
 
     main(args.database, args.output_filename)

--- a/conv/netex_to_db.py
+++ b/conv/netex_to_db.py
@@ -21,10 +21,14 @@ def netex_to_db(filenames: set[Path], database: Path, clean_database: bool = Tru
         for filename in filenames:
             xml_storage = XmlStorage(filename)
             for sub_file, real_filename in xml_storage.open_netex_file():
+                log_all(logging.INFO, f"[netex_to_db] loading {real_filename}")
                 insert_database(storage, interesting_classes, sub_file)
 
+        log_all(logging.INFO, "[netex_to_db] resolving references")
         resolve(storage)
+        log_all(logging.INFO, "[netex_to_db] resolving embeddings")
         resolve_embeddings(storage)
+        log_all(logging.INFO, f"[netex_to_db] done: {database}")
 
 
 def main(filenames: list[str], database: str, clean_database: bool = True) -> None:
@@ -48,11 +52,15 @@ def main(filenames: list[str], database: str, clean_database: bool = True) -> No
 if __name__ == '__main__':
     import argparse
 
+    from utils.aux_logging import prepare_logger
+
     argument_parser = argparse.ArgumentParser(description='Import any NeTEx source into lmdb')
     argument_parser.add_argument('netex', nargs='+', default=[], help='NeTEx files')
     argument_parser.add_argument('database', type=str, help='The lmdb to be overwritten with the NeTEx context')
     argument_parser.add_argument('--clean_database', action="store_true", help='Clean the current file', default=True)
+    argument_parser.add_argument('--log_file', type=str, required=False, help='the logfile')
     args = argument_parser.parse_args()
+    prepare_logger(logging.INFO, args.log_file)
 
     try:
         main(args.netex, args.database, args.clean_database)

--- a/storage/lxml/core/insert.py
+++ b/storage/lxml/core/insert.py
@@ -1,7 +1,10 @@
 import inspect
+import logging
 import warnings
 from typing import IO, Any
 from zoneinfo import ZoneInfo
+
+from utils.aux_logging import log_once
 
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.parsers import XmlParser
@@ -180,8 +183,7 @@ def insert_database(
 
             elif localname == "TypeOfFrameRef":
                 if type_of_frame_filter is not None and element.attrib["ref"] not in type_of_frame_filter:
-                    # TODO: log a single warning that an unknown TypeOfFrame is found, and is not processed
-                    print(f"{element.attrib['ref']} is not a known TypeOfFrame")
+                    log_once(logging.WARNING, element.attrib["ref"], f"{element.attrib['ref']} is not a known TypeOfFrame")
                     skip_frame = True
 
             if localname in all_frames:

--- a/storage/mdbx/core/implementation.py
+++ b/storage/mdbx/core/implementation.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from pathlib import Path
 from sys import exception
@@ -21,6 +22,7 @@ from domain.netex.services.recursive_attributes import only_references
 from domain.netex.services.utils import get_boring_classes
 from domain.utils import get_object_name
 from storage.mdbx.serialization.byteserializer import ByteSerializer
+from utils.aux_logging import log_all
 
 DB_CLASS_IDX = bytes(b'_class_idx')
 DB_UNRESOLVED = bytes(b'_unresolved')
@@ -209,7 +211,7 @@ class MdbxStorage:
             obj = self.load_object_by_full_key(txn, full_reference)
             if skip_existing:
                 if obj.__class__ not in clazzes:
-                    print(obj.__class__, clazzes)
+                    log_all(logging.DEBUG, f"yielding unexpected class {obj.__class__} not in interesting classes {clazzes}")
                     yield obj
             else:
                 yield obj
@@ -481,7 +483,7 @@ class MdbxStorage:
 
             if True:
                 # TODO: Fallback should not happen, because the references should already have been updated, but since we are here
-                print("Fallback...")
+                log_all(logging.WARNING, f"[load_object_by_reference] fallback prefix-scan for ref {ref.ref}")
                 prefix = self.serializer.encode_prefix(str(ref.ref), None, False)
                 cursor = txn.cursor(db_id_idx)
                 for check_key, resolved_idx in cursor.iter(prefix):

--- a/storage/mdbx/core/implementation_mp.py
+++ b/storage/mdbx/core/implementation_mp.py
@@ -1,7 +1,10 @@
+import logging
 from pathlib import Path
 from types import TracebackType
 from typing import Optional, Type, Literal, Iterable
 import multiprocessing as mp
+
+from utils.aux_logging import log_all
 
 from mdbx.mdbx import DBI, Env
 
@@ -44,7 +47,7 @@ class MdbxStorageMP(MdbxStorage):
         return super().__exit__(exception_type, exception_value, exception_traceback)
 
     def insert_objects_on_queue(self, klass: type[Tid], objects: Iterable[Tid], empty: bool = False) -> None:
-        print(klass)
+        log_all(logging.DEBUG, f"[mp] insert_objects_on_queue {klass}")
 
         if self.readonly:
             raise

--- a/storage/mdbx/core/implementation_queue.py
+++ b/storage/mdbx/core/implementation_queue.py
@@ -1,6 +1,9 @@
+import logging
 from pathlib import Path
 from typing import Iterable, Any
 import multiprocessing as mp
+
+from utils.aux_logging import log_all
 
 from domain.netex.services.model_typing import Tid
 from domain.netex.services.recursive_attributes import only_references
@@ -16,7 +19,7 @@ class MdbxStorageQueue(MdbxStorage):
         self.queue = queue
 
     def insert_objects_on_queue(self, klass: type[Tid], objects: Iterable[Tid], empty: bool = False) -> None:
-        print(klass)
+        log_all(logging.DEBUG, f"[queue] insert_objects_on_queue {klass}")
 
         this_class_idx = self.class_idx[klass]
 

--- a/storage/mdbx/core/references.py
+++ b/storage/mdbx/core/references.py
@@ -1,6 +1,9 @@
+import logging
+
 from mdbx import MDBXCursorOp, MDBXDBFlags
 
 from domain.netex.indexes.inverse_class import collect_classes_index
+from utils.aux_logging import log_all
 from domain.netex.services.model_typing import Tid
 from domain.netex.model import EntityStructure, Network, NameOfClass
 from domain.netex.services.recursive_attributes import only_reference_objects, only_embedding, embedding_obj_iter
@@ -64,8 +67,6 @@ def variant_of_candidate_in_list(storage, candidate, obj, unresolved_pairs: dict
 
     # TODO: Abstract the separator, so it is uniform through the code
     separator = bytes([ByteSerializer.SEPARATOR])
-
-    print(candidate)
 
     if candidate in unresolved_pairs:
         return candidate, False, False, candidate
@@ -136,9 +137,11 @@ def resolve_embeddings(storage: MdbxStorage):
 
         almost_resolved_queue = {}
 
-        print(missing_classes)
+        log_all(logging.INFO, f"[resolve_embeddings] {len(unresolved_pairs)} unresolved refs, "
+                              f"scanning {len(class_count)} class maps for {len(missing_classes)} missing classes")
 
         for clazz, count in sorted(class_count.items(), key=lambda item: item[1]):
+            log_all(logging.INFO, f"[resolve_embeddings] scanning {clazz.__name__} ({count} objects)")
             db = txn.open_map(storage.class_idx[clazz], flags=MDBXDBFlags.MDBX_DB_DEFAULTS)
             with txn.cursor(db) as cur:
                 for idx, value in cur.iter():
@@ -252,16 +255,22 @@ def resolve(storage: MdbxStorage) -> None:
         
     separator = bytes([ByteSerializer.SEPARATOR])
 
+    seen_count = 0
+
     with storage.env.rw_transaction() as txn:
         db_unresolved = txn.open_map(DB_UNRESOLVED, flags=DB_UNRESOLVED_FLAGS)
         db_id_idx = txn.open_map(DB_ID_IDX, flags=DB_ID_IDX_FLAGS)
         db_reference_forward = txn.open_map(DB_REFERENCE_OUTWARD, flags=DB_REFERENCE_OUTWARD_FLAGS)
 
+        log_all(logging.INFO, "[resolve] resolving references")
         unresolved_cursor = txn.cursor(db=db_unresolved)
         for it in unresolved_cursor.iter_dupsort_rows():
             references_to_fix: list[tuple] = []
 
             for idx, value in it:
+                seen_count += 1
+                if seen_count % 1_000_000 == 0:
+                    log_all(logging.INFO, f"[resolve] {seen_count} references processed...")
                 parts: list[str] | None = None
                 prefix: str | None = None
                 resolved_idx = db_id_idx.get(txn, value)  # This will be the id + version + class check

--- a/storage/mdbx/tools/graph.py
+++ b/storage/mdbx/tools/graph.py
@@ -1,8 +1,10 @@
+import logging
 from typing import Generator
 
 from mdbx.mdbx import TXN
 
 from domain.netex.services.model_typing import Tid
+from utils.aux_logging import log_all
 from storage.mdbx.core.implementation import (
     MdbxStorage,
     DB_ID_IDX,
@@ -254,13 +256,16 @@ def list_forward_examples(order: List[bytes], graph: Dict[bytes, Set[bytes]], li
 
 # --- 7) streaming export generator ---
 def export_objects(txn: TXN, storage: MdbxStorage) -> Iterable[Any]:
+    log_all(logging.INFO, "[export_objects] building export order...")
     graph = build_graph(txn)
     order = order_graph(graph, storage)
-    # quick diagnostics (log when you want)
     total_forwards = count_forward_refs(order, graph)
-    # optional: print or log
-    # print(f"[export_objects] nodes={len(order)} forward_refs={total_forwards}")
-    # stream objects
-    for full_key in order:
+    total = len(order)
+    log_all(logging.INFO, f"[export_objects] exporting {total} objects ({total_forwards} forward references)")
+    # stream objects (consumed lazily during XML serialisation)
+    for i, full_key in enumerate(order, start=1):
+        if i % 100_000 == 0:
+            log_all(logging.INFO, f"[export_objects] {i}/{total} objects exported...")
         yield storage.load_object_by_full_key(txn, full_key)
+    log_all(logging.INFO, f"[export_objects] {total} objects exported")
 


### PR DESCRIPTION
A few small changes to improve logging:

 * progress logging is added to the long running processes (`netex_to_db`, `epip_db_to_xml`, `netex_db_to_generalframe`)
 * `print()` calls are replaced with `log_all()` / `log_once()`
 * `--log_file` is added to all scripts along with `prepare_logger()`