### PR TITLE
if _tmp it is removed more reliable (on windows)

### DIFF
--- a/conv/gtfs_import_to_db.py
+++ b/conv/gtfs_import_to_db.py
@@ -7,12 +7,19 @@ import os
 
 
 def gtfs_import_to_db(source: Path, target: Path) -> None:
-    # Workaround for https://github.com/duckdb/duckdb/issues/8261
+    # Remove target file if it exists (workaround for DuckDB issue)
     try:
-        os.remove(target.resolve())
-    except OSError:
-        pass
+        target.resolve().unlink(missing_ok=True)
+    except OSError as e:
+        print(f"Warning: Could not remove target file {target}: {e}")
 
+    # Ensure temporary files are cleaned up before operation
+    temp_files = ['_tmp', '_tmp2']  # Add any other temp files you use
+    for temp_file in temp_files:
+        try:
+            Path(temp_file).unlink(missing_ok=True)
+        except OSError:
+            pass
     load_gtfs_to_duckdb(source, target)
 
 

--- a/domain/gtfs/services/gtfs_to_duckdb.py
+++ b/domain/gtfs/services/gtfs_to_duckdb.py
@@ -68,6 +68,7 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
                         with open('_tmp', 'wb') as tmp_file:
                             with open(filename, 'rb') as src_file:
                                 tmp_file.write(src_file.read())
+                    finally:
                         os.remove(filename)
 
             else:
@@ -86,6 +87,7 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
                     with open('_tmp', 'wb') as tmp_file:
                         with open(filename, 'rb') as src_file:
                             tmp_file.write(src_file.read())
+                finally:
                     os.remove(filename)
 
             filename = '_tmp'

--- a/domain/gtfs/services/gtfs_to_duckdb.py
+++ b/domain/gtfs/services/gtfs_to_duckdb.py
@@ -65,11 +65,7 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
                         os.rename(filename, '_tmp')
                     except OSError as e:
                         # Alternative approach if rename fails
-                        with open('_tmp', 'wb') as tmp_file:
-                            with open(filename, 'rb') as src_file:
-                                tmp_file.write(src_file.read())
-                    finally:
-                        os.remove(filename)
+                        raise e
 
             else:
                 with zip_file.open(filename, mode='r') as f:
@@ -84,11 +80,7 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
                     os.rename(filename, '_tmp')
                 except OSError as e:
                     # Alternative approach if rename fails
-                    with open('_tmp', 'wb') as tmp_file:
-                        with open(filename, 'rb') as src_file:
-                            tmp_file.write(src_file.read())
-                finally:
-                    os.remove(filename)
+                    raise e
 
             filename = '_tmp'
 
@@ -107,7 +99,7 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
             cur.execute(sql_create_table)
 
             if filename == '_tmp':
-                os.remove('_tmp')
+                Path('_tmp').unlink(missing_ok=True)
 
             for column in column_mapping.keys() - this_mapping.keys():
                 datatype = column_mapping.get(column, 'VARCHAR')

--- a/domain/gtfs/services/gtfs_to_duckdb.py
+++ b/domain/gtfs/services/gtfs_to_duckdb.py
@@ -59,7 +59,17 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
                             f_out.writelines(g)
                 else:
                     zip_file.extract(filename)
-                    os.rename(filename, '_tmp')
+                    try:
+                        # Remove destination if it exists
+                        Path('_tmp').unlink(missing_ok=True)
+                        os.rename(filename, '_tmp')
+                    except OSError as e:
+                        # Alternative approach if rename fails
+                        with open('_tmp', 'wb') as tmp_file:
+                            with open(filename, 'rb') as src_file:
+                                tmp_file.write(src_file.read())
+                        os.remove(filename)
+
             else:
                 with zip_file.open(filename, mode='r') as f:
                     g = io.TextIOWrapper(f, 'utf-8')
@@ -67,7 +77,16 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
                     header = next(reader)
 
                 zip_file.extract(filename)
-                os.rename(filename, '_tmp')
+                try:
+                    # Remove destination if it exists
+                    Path('_tmp').unlink(missing_ok=True)
+                    os.rename(filename, '_tmp')
+                except OSError as e:
+                    # Alternative approach if rename fails
+                    with open('_tmp', 'wb') as tmp_file:
+                        with open(filename, 'rb') as src_file:
+                            tmp_file.write(src_file.read())
+                    os.remove(filename)
 
             filename = '_tmp'
 


### PR DESCRIPTION
in some cases the _tmp remains in the file system. Then os.rename is not happy. So made more robust and really make sure that _tmp is removed.