### PR TITLE
when not a gtfs the process should fail.

### DIFF
--- a/conv/gtfs_import_to_db.py
+++ b/conv/gtfs_import_to_db.py
@@ -6,23 +6,23 @@ from utils.aux_logging import log_all, prepare_logger
 import os
 
 
-def gtfs_import_to_db(source: Path, target: Path) -> None:
+def gtfs_import_to_db(source: Path, target: Path) -> int:
     # Workaround for https://github.com/duckdb/duckdb/issues/8261
     try:
         os.remove(target.resolve())
     except OSError:
         pass
 
-    load_gtfs_to_duckdb(source, target)
+    return load_gtfs_to_duckdb(source, target)
 
 
-def main(gtfs_file: str, database_file: str) -> None:
+def main(gtfs_file: str, database_file: str) -> int:
     gtfs_path = Path(gtfs_file)
     if not gtfs_path.exists():
         log_all(logging.ERROR, f"{gtfs_path} does not exist.")
-
+        return 1
     else:
-        gtfs_import_to_db(gtfs_path, Path(database_file))
+        return gtfs_import_to_db(gtfs_path, Path(database_file))
 
 
 if __name__ == "__main__":

--- a/domain/gtfs/services/gtfs_to_duckdb.py
+++ b/domain/gtfs/services/gtfs_to_duckdb.py
@@ -116,7 +116,7 @@ def load_gtfs_to_duckdb(zip_file: Path, database_file: Path) -> int:
     # check if this is a GTFS file
     if len(set(zf.namelist()) & {'agency.txt', 'routes.txt', 'trips.txt', 'stop_times.txt'}) == 0:
         log_all(logging.ERROR, 'This is not a GTFS file')
-        return 1
+        return -1
 
     _handle_file(con, zf, 'feed_info.txt', feed_info_txt)
     _handle_file(con, zf, 'agency.txt', agency_txt)

--- a/domain/gtfs/services/gtfs_to_duckdb.py
+++ b/domain/gtfs/services/gtfs_to_duckdb.py
@@ -108,7 +108,7 @@ def _handle_file(con: duckdb.DuckDBPyConnection, zip_file: zipfile.ZipFile, file
                 cur.execute(sql_create_table)
 
 
-def load_gtfs_to_duckdb(zip_file: Path, database_file: Path) -> None:
+def load_gtfs_to_duckdb(zip_file: Path, database_file: Path) -> int:
     con: duckdb.DuckDBPyConnection = duckdb.connect(database=database_file)
 
     zf = zipfile.ZipFile(zip_file.resolve())
@@ -116,7 +116,7 @@ def load_gtfs_to_duckdb(zip_file: Path, database_file: Path) -> None:
     # check if this is a GTFS file
     if len(set(zf.namelist()) & {'agency.txt', 'routes.txt', 'trips.txt', 'stop_times.txt'}) == 0:
         log_all(logging.ERROR, 'This is not a GTFS file')
-        return
+        return 1
 
     _handle_file(con, zf, 'feed_info.txt', feed_info_txt)
     _handle_file(con, zf, 'agency.txt', agency_txt)
@@ -136,3 +136,4 @@ def load_gtfs_to_duckdb(zip_file: Path, database_file: Path) -> None:
     handle_single_agency(con)
     update_empty_enumerations(con)
     update_empty_service_id(con)
+    return 0


### PR DESCRIPTION
the gtfs import does not fail when it is not a gtfs file, it just logs it. Then script_runner continues and runs into a problem.