### PR TITLE
Fix copy_map in gtfs_db_to_db copying from the wrong storage

### DIFF
--- a/conv/gtfs_db_to_db.py
+++ b/conv/gtfs_db_to_db.py
@@ -37,7 +37,7 @@ def gtfs_db_to_db(source_database: Path, target_database: Path, clean_database: 
                 # Copy tables that we don't change as-is.
                 with db_read.env.ro_transaction() as txn_read:
                     for clazz in [DataSource, Codespace, StopPlace, PassengerStopAssignment, ScheduledStopPoint, StopArea, InterchangeRule, Version]:
-                        db_write.copy_map(txn_read, db_write, txn_write, clazz)
+                        db_read.copy_map(txn_read, db_write, txn_write, clazz)
 
                     # service_calendars: List[ServiceCalendar] = list(db_read.iter_only_objects(txn_read, ServiceCalendar))
 


### PR DESCRIPTION
Fixes #101

copy_map reads via self.iter_only_objects(), so it needs to be called on
the storage holding the source data. gtfs_db_to_db calls it on db_write
instead of db_read, so PassengerStopAssignment/ScheduledStopPoint/StopPlace
etc. lose their outgoing references (or come out empty entirely).
epip_db_to_db.py does the same copy correctly (source_db.copy_map(...),
line 183).

Introduced in e5a8107 during the netexio -> mdbx migration, no test covers
this path. Same root cause as #101 (5t), also reproduced it converting
Trenitalia's NeTEx EPIP feed: stop_times.txt referenced 1935 stop_ids but
stops.txt came out empty.